### PR TITLE
fix: update default help class

### DIFF
--- a/src/_test-help-class.ts
+++ b/src/_test-help-class.ts
@@ -1,7 +1,7 @@
 // `getHelpClass` tests require an oclif project for testing so
 // it is re-using the setup here to be able to do a lookup for
 // this sample help class file in tests, although it is not needed
-// for @oclif/plugin-help itself.
+// for @oclif/help itself.
 
 import {HelpBase} from '.'
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -64,7 +64,7 @@ function extractClass(exported: any): HelpBaseDerived {
   return exported && exported.default ? exported.default : exported
 }
 
-export function getHelpClass(config: IConfig, defaultClass = '@oclif/plugin-help'): HelpBaseDerived {
+export function getHelpClass(config: IConfig, defaultClass = '@oclif/help'): HelpBaseDerived {
   const pjson = config.pjson
   const configuredClass = pjson && pjson.oclif &&  pjson.oclif.helpClass
 
@@ -82,6 +82,6 @@ export function getHelpClass(config: IConfig, defaultClass = '@oclif/plugin-help
     const exported = require(defaultModulePath)
     return extractClass(exported) as HelpBaseDerived
   } catch (error) {
-    throw new Error(`Could not load a help class, consider installing the @oclif/plugin-help package, failed with message:\n${error.message}`)
+    throw new Error(`Could not load a help class, consider installing the @oclif/help package, failed with message:\n${error.message}`)
   }
 }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -36,7 +36,7 @@ describe('util', () => {
       test
       .it('throws an error when failing to load the default help class', () => {
         delete config.pjson.oclif.helpClass
-        expect(() => getHelpClass(config, 'does-not-exist-default-plugin')).to.throw('Could not load a help class, consider installing the @oclif/plugin-help package, failed with message:')
+        expect(() => getHelpClass(config, 'does-not-exist-default-plugin')).to.throw('Could not load a help class, consider installing the @oclif/help package, failed with message:')
       })
 
       test


### PR DESCRIPTION
Updates the default help import from `@oclif/plugin-help` to `@oclif/help`